### PR TITLE
Comment out along steps in the course

### DIFF
--- a/02_security/authentication/my-consumer.yaml
+++ b/02_security/authentication/my-consumer.yaml
@@ -7,18 +7,19 @@ metadata:
 spec:
   authentication:
     type: tls
-  authorization:
-    type: simple
-    acls:
-      - resource:
-          type: topic
-          name: my-topic
-        operation: Read
-      - resource:
-          type: topic
-          name: my-topic
-        operation: Describe
-      - resource:
-          type: group
-          name: my-hello-world-consumer
-        operation: Read
+# Remove following # at "5. Authorize Connections"
+#  authorization:
+#    type: simple
+#    acls:
+#      - resource:
+#          type: topic
+#          name: my-topic
+#        operation: Read
+#      - resource:
+#          type: topic
+#          name: my-topic
+#        operation: Describe
+#      - resource:
+#          type: group
+#          name: my-hello-world-consumer
+#        operation: Read

--- a/02_security/authentication/my-producer.yaml
+++ b/02_security/authentication/my-producer.yaml
@@ -7,14 +7,15 @@ metadata:
 spec:
   authentication:
     type: tls
-  authorization:
-    type: simple
-    acls:
-      - resource:
-          type: topic
-          name: my-topic
-        operation: Write
-      - resource:
-          type: topic
-          name: my-topic
-        operation: Describe
+# Remove following # at "5. Authorize Connections"
+#  authorization:
+#    type: simple
+#    acls:
+#      - resource:
+#          type: topic
+#          name: my-topic
+#        operation: Write
+#      - resource:
+#          type: topic
+#          name: my-topic
+#        operation: Describe


### PR DESCRIPTION
KafkaUser.spec.authorization is added after confirming the old consumer and producer stopped working. Thus in the original asset, KafkaUser.spec.authorization should not be included from the start to avoid confusion although this is not a big deal.